### PR TITLE
Add Bites to apps submenu and split expanded apps into two rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,10 +68,15 @@
     <button class="extra-button"><a href="/apps/txtpod">txtpod</a></button>
     <button id="apps-ellipsis" class="extra-button" aria-expanded="false">···</button>
   </div>
-  <div id="more-apps" class="extra-buttons" style="display:none;">
-    <button class="extra-button"><a href="/apps/notsobusy">NotSoBusy</a></button>
-    <button class="extra-button"><a href="/apps/kiwicamping">KiwiCamping</a></button>
-    <button class="extra-button"><a href="/apps/ftnss-workouts">ftnss Workouts</a></button>
+  <div id="more-apps" style="display:none;">
+    <div class="extra-buttons">
+      <button class="extra-button"><a href="/apps/bites">Bites</a></button>
+      <button class="extra-button"><a href="/apps/notsobusy">NotSoBusy</a></button>
+    </div>
+    <div class="extra-buttons">
+      <button class="extra-button"><a href="/apps/kiwicamping">KiwiCamping</a></button>
+      <button class="extra-button"><a href="/apps/ftnss-workouts">ftnss Workouts</a></button>
+    </div>
   </div>
   </div>
 
@@ -123,7 +128,7 @@
   const moreApps = document.getElementById('more-apps');
   if (appsEllipsis && moreApps) {
     appsEllipsis.addEventListener('click', function() {
-      moreApps.style.display = 'flex';
+      moreApps.style.display = 'block';
       appsEllipsis.style.display = 'none';
       appsEllipsis.setAttribute('aria-expanded', 'true');
     });


### PR DESCRIPTION
### Motivation
- Add a new `Bites` entry to the apps submenu and place it before `NotSoBusy` in the expanded view.
- Present the expanded apps in two rows so the menu reads as two-column pairs rather than a single line of buttons.
- Keep the reveal interaction for the expanded apps consistent with the new two-row structure.

### Description
- Updated `index.html` to add a `Bites` button linking to `/apps/bites` inside the expanded apps area (`more-apps`).
- Wrapped expanded items in two `<div class="extra-buttons">` rows so the expanded menu shows `Bites | NotSoBusy` on the first row and `KiwiCamping | ftnss Workouts` on the second.
- Removed the `extra-buttons` class from the parent `#more-apps` and adjusted the reveal script to set `moreApps.style.display = 'block'` instead of `'flex'` to accommodate the new nested rows.
- Minor whitespace/indentation cleanup in `index.html` to keep markup consistent.

### Testing
- Started a local server with `python -m http.server 8000` and confirmed `index.html` was served successfully.
- Multiple automated `Playwright` attempts to click `#apps-ellipsis` timed out (click locator not found/visible) and therefore failed.
- A final automated `Playwright` run loaded the page and captured a full-page screenshot successfully to verify the static layout render.
- A `curl` fetch of `/index.html` completed successfully to verify the updated markup was being served.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e3feee6c833191017461e314ba9e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new app entry and restructures the expanded apps menu layout.
> 
> - Adds `Bites` link to the expanded `more-apps` section, positioned before `NotSoBusy`
> - Reworks `#more-apps` into two `extra-buttons` rows (removes parent `extra-buttons` class) for a two-row layout
> - Updates reveal handler to set `moreApps.style.display = 'block'` (was `flex`) to match the new structure
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7badd9b4216a2052972e6c181deab8b136e3f99d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->